### PR TITLE
Feature/debug to main 

### DIFF
--- a/backend/app/_compile_worker.py
+++ b/backend/app/_compile_worker.py
@@ -166,6 +166,26 @@ def _run(tmppath: str, source: str, shots: int, simulator: str, seed: int | None
         except Exception:
             pass  # if noisy sim fails, return ideal counts only
 
+    # State snapshots — extract state_result() calls if present in source
+    state_snapshots: list[list[dict]] | None = None
+    if re.search(r'\bstate_result\s*\(', source):
+        try:
+            if simulator == "statevector":
+                # Already have a statevector result — extract directly
+                state_snapshots = _extract_state_snapshots(result)
+            elif n_qubits <= MAX_QUBITS_STATEVECTOR:
+                # Stabilizer was used for counts; run 1-shot statevector pass for states
+                sv_em = (
+                    guppy_fn.emulator(n_qubits=n_qubits)
+                    .with_shots(1)
+                    .statevector_sim()
+                )
+                if seed is not None:
+                    sv_em = sv_em.with_seed(seed)
+                state_snapshots = _extract_state_snapshots(sv_em.run())
+        except Exception:
+            pass
+
     print(json.dumps({
         "status":          "ok",
         "counts":          counts,
@@ -175,6 +195,7 @@ def _run(tmppath: str, source: str, shots: int, simulator: str, seed: int | None
         "hugr_json":       hugr_json,
         "warnings":        [],
         "qubit_count":     n_qubits,
+        "state_snapshots": state_snapshots,
     }))
 
 
@@ -186,6 +207,8 @@ def _flatten_counts(result) -> dict[str, int]:
     for shot in result.results:
         parts = []
         for _, v in shot.entries:
+            if isinstance(v, str):
+                continue  # state_result() stores artifact file paths — skip them
             if isinstance(v, list):
                 parts.append("".join(str(int(b)) for b in v))
             else:
@@ -206,7 +229,10 @@ def _extract_register_names(result) -> list[str] | None:
     """
     if not result.results:
         return None
-    reg_bits = result.results[0].to_register_bits()
+    try:
+        reg_bits = result.results[0].to_register_bits()
+    except Exception:
+        return None  # state_result() artifact paths confuse to_register_bits()
     if not reg_bits:
         return None
     names: list[str] = []
@@ -219,6 +245,45 @@ def _extract_register_names(result) -> list[str] | None:
     if all(re.fullmatch(r"\d+", n.split("[")[0]) for n in names):
         return None
     return names or None
+
+
+def _extract_state_snapshots(result) -> list[list[dict]] | None:
+    """Serialize state_result() snapshots from shot 0 into JSON-safe dicts.
+
+    Returns [[{tag, num_qubits, specified_qubits, distribution}, ...]] (one outer
+    list per captured shot, currently always length 1) or None if no snapshots.
+    """
+    try:
+        partial_states = result.partial_states()   # list[list[tuple[str, PartialVector]]]
+        if not partial_states:
+            return None
+        all_shots: list[list[dict]] = []
+        for shot_states in partial_states[:1]:     # only shot 0 for display
+            shot_snaps: list[dict] = []
+            for tag, pv in shot_states:
+                n_specified = len(pv.specified_qubits)
+                if n_specified > 8:                # 2^8 = 256 amplitudes max
+                    continue
+                try:
+                    distribution = [
+                        {
+                            "probability": float(ts.probability),
+                            "amplitudes":  [[float(c.real), float(c.imag)] for c in ts.state],
+                        }
+                        for ts in pv.state_distribution()
+                    ]
+                    shot_snaps.append({
+                        "tag":              tag,
+                        "num_qubits":       pv.total_qubits,
+                        "specified_qubits": list(pv.specified_qubits),
+                        "distribution":     distribution,
+                    })
+                except Exception:
+                    pass
+            all_shots.append(shot_snaps)
+        return all_shots if any(s for s in all_shots) else None
+    except Exception:
+        return None
 
 
 # ── Error rendering ────────────────────────────────────────────────────────

--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from .models import (
     CompileError, CompileSuccess, CompileWarning,
-    ErrorKind, HugrNode, SimulationResults,
+    ErrorKind, HugrNode, SimulationResults, StateSnapshot, StateTracedState,
 )
 from .sandbox import run_subprocess
 
@@ -115,11 +115,34 @@ async def compile_and_simulate(
         compile_time_ms=elapsed_ms,
     )
 
+    raw_snaps = data.get("state_snapshots")
+    state_snapshots = None
+    if raw_snaps:
+        state_snapshots = [
+            [
+                StateSnapshot(
+                    tag=snap["tag"],
+                    num_qubits=snap["num_qubits"],
+                    specified_qubits=snap["specified_qubits"],
+                    distribution=[
+                        StateTracedState(
+                            probability=entry["probability"],
+                            amplitudes=entry["amplitudes"],
+                        )
+                        for entry in snap["distribution"]
+                    ],
+                )
+                for snap in shot
+            ]
+            for shot in raw_snaps
+        ]
+
     sim_ok = SimulationResults(
         counts=data.get("counts", {}),
         noisy_counts=data.get("noisy_counts"),
         register_names=data.get("register_names"),
         simulate_time_ms=elapsed_ms,
+        state_snapshots=state_snapshots,
     )
 
     return compile_ok, sim_ok

--- a/backend/app/examples_data.py
+++ b/backend/app/examples_data.py
@@ -199,4 +199,37 @@ def main() -> None:
 main.check()
 ''',
     ),
+    Example(
+        id="state-debug",
+        title="State Snapshots",
+        description="Use state_result() to inspect the quantum state mid-circuit. Guppy's equivalent of print() debugging.",
+        tags=["debugging", "statevector"],
+        group="Debugging",
+        qubit_count=2,
+        default_shots=256,
+        source='''\
+from guppylang import guppy
+from guppylang.std.quantum import qubit, h, cx, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result as guppy_result
+
+@guppy
+def main() -> None:
+    q0 = qubit()
+    q1 = qubit()
+
+    state_result("initial", q0, q1)   # |00>
+
+    h(q0)
+    state_result("after_h", q0, q1)   # |+0> = (|00> + |10>)/sqrt(2)
+
+    cx(q0, q1)
+    state_result("bell", q0, q1)      # (|00> + |11>)/sqrt(2)
+
+    guppy_result("m0", measure(q0))
+    guppy_result("m1", measure(q1))
+
+main.check()
+''',
+    ),
 ]

--- a/backend/app/examples_data.py
+++ b/backend/app/examples_data.py
@@ -201,7 +201,7 @@ main.check()
     ),
     Example(
         id="state-debug",
-        title="State Snapshots",
+        title="Bell Pair Inspection",
         description="Use state_result() to inspect the quantum state mid-circuit. Guppy's equivalent of print() debugging.",
         tags=["debugging", "statevector"],
         group="Debugging",
@@ -215,19 +215,242 @@ from guppylang.std.builtins import result as guppy_result
 
 @guppy
 def main() -> None:
+    """Bell pair preparation with state snapshots.
+
+    Walks through the two-gate sequence that creates a Bell state,
+    capturing the wavefunction after each step so you can see superposition
+    and entanglement appear one gate at a time.
+
+    Switch to Statevector simulator to see the State tab.
+    """
     q0 = qubit()
     q1 = qubit()
 
-    state_result("initial", q0, q1)   # |00>
+    state_result("1. initial", q0, q1)       # |00> -- both qubits in ground state
 
+    # H puts q0 into equal superposition
     h(q0)
-    state_result("after_h", q0, q1)   # |+0> = (|00> + |10>)/sqrt(2)
+    state_result("2. after H", q0, q1)       # (|00> + |10>)/sqrt(2) -- q0 in |+>, q1 still |0>
 
+    # CNOT entangles q0 and q1 -- creates the Bell state
     cx(q0, q1)
-    state_result("bell", q0, q1)      # (|00> + |11>)/sqrt(2)
+    state_result("3. Bell state", q0, q1)    # (|00> + |11>)/sqrt(2) -- maximally entangled
 
     guppy_result("m0", measure(q0))
     guppy_result("m1", measure(q1))
+
+main.check()
+''',
+    ),
+    Example(
+        id="teleport-debug",
+        title="Quantum Teleportation Inspection",
+        description="Watch entanglement build and collapse during quantum teleportation using state_result() snapshots at each stage.",
+        tags=["debugging", "teleportation", "statevector", "intermediate"],
+        group="Debugging",
+        qubit_count=3,
+        default_shots=256,
+        source='''\
+from guppylang import guppy
+from guppylang.std.builtins import owned, result
+from guppylang.std.quantum import cx, h, measure, qubit, x, z
+from guppylang.std.debug import state_result
+
+@guppy
+def main() -> None:
+    """Quantum teleportation with state inspection.
+
+    Teleports src (prepared in |+>) to tgt using an entangled ancilla tmp.
+    state_result() snapshots the full 3-qubit wavefunction at each stage,
+    letting you watch entanglement build and collapse through the protocol.
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    src = qubit()   # qubit to teleport — prepared in |+>
+    tmp = qubit()   # ancilla — entangled with tgt to form the Bell channel
+    tgt = qubit()   # destination qubit
+
+    # Prepare src in |+> = (|0> + |1>)/sqrt(2)
+    h(src)
+    state_result("1. src in |+>", src, tmp, tgt)
+
+    # Entangle tmp and tgt — creates the Bell channel
+    h(tmp)
+    cx(tmp, tgt)
+    state_result("2. Bell channel ready", src, tmp, tgt)
+
+    # Joint Bell measurement on src and tmp
+    cx(src, tmp)
+    h(src)
+    state_result("3. Before measurement", src, tmp, tgt)
+
+    # Mid-circuit measurement — wavefunction collapses here
+    m_src = measure(src)
+    m_tmp = measure(tmp)
+
+    # Classical feedforward corrections on tgt
+    if m_tmp:
+        x(tgt)
+    if m_src:
+        z(tgt)
+
+    # tgt now holds the teleported |+> state
+    state_result("4. After correction (tgt only)", tgt)
+    result("tgt", measure(tgt))
+
+main.check()
+''',
+    ),
+    Example(
+        id="ghz-debug",
+        title="GHZ State Inspection",
+        description="Watch 3-qubit GHZ entanglement spread step by step using state_result() as each CNOT is applied.",
+        tags=["debugging", "entanglement", "statevector", "intermediate"],
+        group="Debugging",
+        qubit_count=3,
+        default_shots=256,
+        source='''\
+from guppylang import guppy
+from guppylang.std.quantum import qubit, h, cx, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result
+
+@guppy
+def main() -> None:
+    """GHZ state preparation with state snapshots.
+
+    Watch entanglement spread qubit by qubit as each CNOT is applied,
+    building the 3-qubit GHZ state (|000> + |111>)/sqrt(2).
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    q0 = qubit()
+    q1 = qubit()
+    q2 = qubit()
+
+    state_result("1. initial", q0, q1, q2)            # |000>
+
+    h(q0)
+    state_result("2. after H on q0", q0, q1, q2)      # (|000> + |100>)/sqrt(2)
+
+    cx(q0, q1)
+    state_result("3. after cx(q0,q1)", q0, q1, q2)    # (|000> + |110>)/sqrt(2)
+
+    cx(q1, q2)
+    state_result("4. GHZ ready", q0, q1, q2)          # (|000> + |111>)/sqrt(2)
+
+    result("q0", measure(q0))
+    result("q1", measure(q1))
+    result("q2", measure(q2))
+
+main.check()
+''',
+    ),
+    Example(
+        id="deutsch-debug",
+        title="Deutsch Algorithm Inspection",
+        description="See phase kickback in action — watch how the oracle encodes f(x) as a global phase and the final H converts it to a measurable bit.",
+        tags=["debugging", "algorithm", "statevector", "intermediate"],
+        group="Debugging",
+        qubit_count=2,
+        default_shots=256,
+        source='''\
+from guppylang import guppy
+from guppylang.std.quantum import qubit, h, cx, x, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result
+
+@guppy
+def main() -> None:
+    """Deutsch algorithm with state snapshots.
+
+    Watch how the balanced oracle encodes f(x) as a global phase via
+    kickback, and how the final Hadamard converts that into a measurable bit.
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    q   = qubit()
+    anc = qubit()
+
+    state_result("1. initial", q, anc)           # |00>
+
+    h(q)
+    x(anc)
+    h(anc)
+    state_result("2. |+-> prepared", q, anc)     # query register in |+->
+
+    # Balanced oracle: f(x) = x
+    cx(q, anc)
+    state_result("3. after oracle", q, anc)      # phase kickback applied
+
+    h(q)
+    state_result("4. after final H", q, anc)     # q collapses to |1> -- balanced
+
+    result("result", measure(q))
+    result("anc", measure(anc))
+
+main.check()
+''',
+    ),
+    Example(
+        id="qec-debug",
+        title="Bit Flip Code Inspection",
+        description="Watch the QEC cycle: encode a logical qubit, inject an error, measure syndromes, and verify the corrected state with state_result().",
+        tags=["debugging", "error-correction", "statevector", "advanced"],
+        group="Debugging",
+        qubit_count=5,
+        default_shots=256,
+        source='''\
+from guppylang import guppy
+from guppylang.std.quantum import qubit, cx, x, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result
+
+@guppy
+def main() -> None:
+    """3-qubit bit-flip code with state snapshots.
+
+    Watch the logical |0> get encoded across three physical qubits,
+    a bit-flip error get injected, syndromes measured, and the state restored.
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    q0 = qubit()
+    q1 = qubit()
+    q2 = qubit()
+
+    state_result("1. initial |000>", q0, q1, q2)
+
+    # Encode logical |0> -> |000>
+    cx(q0, q1)
+    cx(q0, q2)
+    state_result("2. encoded |000>", q0, q1, q2)
+
+    # Inject a bit-flip error on q1
+    x(q1)
+    state_result("3. after error on q1", q0, q1, q2)
+
+    # Syndrome measurement via ancilla qubits
+    anc0 = qubit()
+    anc1 = qubit()
+    cx(q0, anc0); cx(q1, anc0)
+    cx(q1, anc1); cx(q2, anc1)
+    s0 = measure(anc0)
+    s1 = measure(anc1)
+
+    # Correction
+    if s0 and not s1:
+        x(q0)
+    if s0 and s1:
+        x(q1)
+    if not s0 and s1:
+        x(q2)
+
+    state_result("4. after correction", q0, q1, q2)
+
+    result("q0", measure(q0))
+    result("q1", measure(q1))
+    result("q2", measure(q2))
 
 main.check()
 ''',

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -68,11 +68,24 @@ class CompileSuccess(BaseModel):
 
 # ── Simulation output ──────────────────────────────────────────────────────
 
+class StateTracedState(BaseModel):
+    probability: float
+    amplitudes:  list[list[float]]   # [[re, im], ...] — one entry per basis state
+
+
+class StateSnapshot(BaseModel):
+    tag:               str
+    num_qubits:        int            # total qubits in the full system
+    specified_qubits:  list[int]      # indices of qubits captured by this call
+    distribution:      list[StateTracedState]
+
+
 class SimulationResults(BaseModel):
     counts:           dict[str, int]
     noisy_counts:     dict[str, int] | None = None
     register_names:   list[str] | None = None
     simulate_time_ms: int
+    state_snapshots:  list[list[StateSnapshot]] | None = None  # [shot][call-order]
 
 
 # ── Run response ───────────────────────────────────────────────────────────

--- a/frontend/src/components/hooks/useRun.ts
+++ b/frontend/src/components/hooks/useRun.ts
@@ -57,7 +57,10 @@ export function useRun() {
 
       if (response.status === 'ok') {
         setRunState({ status: 'success', response, elapsed_ms });
-        setActiveTab('results');
+        const hasStateSnapshots =
+          (response.results?.state_snapshots?.length ?? 0) > 0 &&
+          (response.results?.state_snapshots?.[0]?.length ?? 0) > 0;
+        setActiveTab(hasStateSnapshots ? 'state' : 'results');
       } else if (response.status === 'compile_error') {
         setRunState({ status: 'compile_error', errors: response.errors ?? [] });
         setActiveTab('output');

--- a/frontend/src/components/hooks/useRun.ts
+++ b/frontend/src/components/hooks/useRun.ts
@@ -30,7 +30,7 @@ export function useRun() {
   }, []);
 
   async function run() {
-    const { source, shots, simulator, seed, noiseModel, errorRate, activeSlot, examples, setRunState, setActiveTab } =
+    const { source, shots, simulator, seed, noiseModel, errorRate, activeSlot, examples, setRunState, setActiveTab, setSimulator } =
       usePlaygroundStore.getState();
 
     const isRunning = ['compiling', 'simulating', 'preparing'].includes(store.runState.status);
@@ -49,6 +49,7 @@ export function useRun() {
     setActiveTab('output');
 
     const effectiveSimulator = /\bstate_result\s*\(/.test(source) ? 'statevector' : simulator;
+    if (effectiveSimulator !== simulator) setSimulator(effectiveSimulator);
 
     try {
       const response = await apiRun({

--- a/frontend/src/components/hooks/useRun.ts
+++ b/frontend/src/components/hooks/useRun.ts
@@ -48,19 +48,22 @@ export function useRun() {
     setRunState({ status: 'compiling' });
     setActiveTab('output');
 
+    const effectiveSimulator = /\bstate_result\s*\(/.test(source) ? 'statevector' : simulator;
+
     try {
       const response = await apiRun({
-        source, filename, shots, simulator, seed,
+        source, filename, shots, simulator: effectiveSimulator, seed,
         ...(noiseModel ? { noise_model: noiseModel, error_rate: errorRate } : {}),
       });
       const elapsed_ms = Math.round(performance.now() - start);
 
       if (response.status === 'ok') {
-        setRunState({ status: 'success', response, elapsed_ms });
+        setRunState({ status: 'success', response, elapsed_ms, simulator: effectiveSimulator });
         const hasStateSnapshots =
           (response.results?.state_snapshots?.length ?? 0) > 0 &&
           (response.results?.state_snapshots?.[0]?.length ?? 0) > 0;
-        setActiveTab(hasStateSnapshots ? 'state' : 'results');
+        const sourceUsesStateResult = /\bstate_result\s*\(/.test(source);
+        setActiveTab((hasStateSnapshots || sourceUsesStateResult) ? 'state' : 'results');
       } else if (response.status === 'compile_error') {
         setRunState({ status: 'compile_error', errors: response.errors ?? [] });
         setActiveTab('output');

--- a/frontend/src/components/output/OutputPane.tsx
+++ b/frontend/src/components/output/OutputPane.tsx
@@ -3,6 +3,7 @@ import { usePlaygroundStore } from '../../lib/store';
 import { useRun } from '../hooks/useRun';
 import TerminalOutput from './TerminalOutput';
 import ResultsTab from './ResultsTab';
+import StateTab from './StateTab';
 import HugrTab from './HugrTab';
 import type { OutputTab, RunState } from '../../lib/types';
 
@@ -57,11 +58,17 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
     document.body.style.userSelect = 'none';
   }
 
-  // Mobile: 3 tabs as before
+  const hasStateSnapshots =
+    runState.status === 'success' &&
+    (runState.response.results?.state_snapshots?.length ?? 0) > 0 &&
+    (runState.response.results?.state_snapshots?.[0]?.length ?? 0) > 0;
+
+  // Mobile: 4 tabs
   if (isMobile) {
     const allTabs: { id: OutputTab; label: string }[] = [
       { id: 'output',  label: 'Output'  },
       { id: 'results', label: 'Results' },
+      { id: 'state',   label: 'State'   },
       { id: 'hugr',    label: 'HUGR'    },
     ];
     return (
@@ -82,12 +89,14 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
               label={tab.label}
               active={activeTab === tab.id}
               onClick={() => setActiveTab(tab.id)}
+              dot={tab.id === 'state' && hasStateSnapshots}
             />
           ))}
         </div>
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           {activeTab === 'output'  && <TerminalOutput />}
           {activeTab === 'results' && <ResultsTab />}
+          {activeTab === 'state'   && <StateTab />}
           {activeTab === 'hugr'    && <HugrTab key={runId} />}
         </div>
         <StatusBar statusInfo={statusInfo} runState={runState} />
@@ -95,12 +104,13 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
     );
   }
 
-  // Desktop: Results/HUGR tabs on top, Output panel fixed at bottom
+  // Desktop: Results / State / HUGR tabs on top, Output panel fixed at bottom
   const topTabs: { id: OutputTab; label: string }[] = [
     { id: 'results', label: 'Results' },
+    { id: 'state',   label: 'State'   },
     { id: 'hugr',    label: 'HUGR'    },
   ];
-  // If activeTab is 'output' (e.g. switched from mobile), treat 'results' as selected
+  // If activeTab is 'output' (switched from mobile), fall back to 'results'
   const topActiveTab: OutputTab = activeTab === 'output' ? 'results' : activeTab;
 
   const splitHighlighted = splitDividerActive || splitDividerHovered;
@@ -126,11 +136,13 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
               label={tab.label}
               active={topActiveTab === tab.id}
               onClick={() => setActiveTab(tab.id)}
+              dot={tab.id === 'state' && hasStateSnapshots}
             />
           ))}
         </div>
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           {topActiveTab === 'results' && <ResultsTab />}
+          {topActiveTab === 'state'   && <StateTab />}
           {topActiveTab === 'hugr'    && <HugrTab key={runId} />}
         </div>
       </div>
@@ -171,9 +183,9 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
 }
 
 function TabButton({
-  label, active, onClick, asLabel,
+  label, active, onClick, asLabel, dot,
 }: {
-  label: string; active: boolean; onClick: () => void; asLabel?: boolean;
+  label: string; active: boolean; onClick: () => void; asLabel?: boolean; dot?: boolean;
 }) {
   const [hovered, setHovered] = React.useState(false);
   return (
@@ -196,9 +208,17 @@ function TabButton({
         cursor: asLabel ? 'default' : 'pointer',
         transition: 'color 0.15s',
         whiteSpace: 'nowrap',
+        display: 'inline-flex', alignItems: 'center', gap: 5,
       }}
     >
       {label}
+      {dot && (
+        <span style={{
+          width: 5, height: 5, borderRadius: '50%', flexShrink: 0,
+          background: active ? 'var(--teal)' : 'var(--text-muted)',
+          transition: 'background 0.15s',
+        }} />
+      )}
     </button>
   );
 }

--- a/frontend/src/components/output/OutputPane.tsx
+++ b/frontend/src/components/output/OutputPane.tsx
@@ -58,10 +58,12 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
     document.body.style.userSelect = 'none';
   }
 
+  const { source } = usePlaygroundStore();
   const hasStateSnapshots =
     runState.status === 'success' &&
     (runState.response.results?.state_snapshots?.length ?? 0) > 0 &&
     (runState.response.results?.state_snapshots?.[0]?.length ?? 0) > 0;
+  const showStateDot = hasStateSnapshots || /\bstate_result\s*\(/.test(source);
 
   // Mobile: 4 tabs
   if (isMobile) {
@@ -89,7 +91,7 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
               label={tab.label}
               active={activeTab === tab.id}
               onClick={() => setActiveTab(tab.id)}
-              dot={tab.id === 'state' && hasStateSnapshots}
+              dot={tab.id === 'state' && showStateDot}
             />
           ))}
         </div>
@@ -136,7 +138,7 @@ export default function OutputPane({ isMobile = false }: { isMobile?: boolean })
               label={tab.label}
               active={topActiveTab === tab.id}
               onClick={() => setActiveTab(tab.id)}
-              dot={tab.id === 'state' && hasStateSnapshots}
+              dot={tab.id === 'state' && showStateDot}
             />
           ))}
         </div>

--- a/frontend/src/components/output/StateTab.tsx
+++ b/frontend/src/components/output/StateTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { usePlaygroundStore } from '../../lib/store';
 import type { StateSnapshot, StateTracedState } from '../../lib/types';
 
@@ -22,18 +22,17 @@ export default function StateTab() {
   }
 
   return (
-    <div style={{
-      flex: 1, overflow: 'auto', padding: 16,
-      display: 'flex', flexDirection: 'column', gap: 12,
-    }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
-          {snapshots.length} state snapshot{snapshots.length !== 1 ? 's' : ''} · shot 0
-        </span>
+    <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+      <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
+            {snapshots.length} state snapshot{snapshots.length !== 1 ? 's' : ''} · shot 0
+          </span>
+        </div>
+        {snapshots.map((snap, i) => (
+          <SnapshotCard key={`${snap.tag}-${i}`} snapshot={snap} index={i} />
+        ))}
       </div>
-      {snapshots.map((snap, i) => (
-        <SnapshotCard key={`${snap.tag}-${i}`} snapshot={snap} index={i} />
-      ))}
     </div>
   );
 }
@@ -108,6 +107,7 @@ function SnapshotCard({ snapshot, index }: { snapshot: StateSnapshot; index: num
 // ── Pure state — equation hero + detail rows ──────────────────────────────
 
 function PureStateBody({ amplitudes, n }: { amplitudes: [number, number][]; n: number }) {
+  const [open, setOpen] = useState(true);
   const probs = amplitudes.map(([re, im]) => re * re + im * im);
   const nonZeroCount = probs.filter(p => p > 1e-9).length;
 
@@ -128,13 +128,14 @@ function PureStateBody({ amplitudes, n }: { amplitudes: [number, number][]; n: n
         <StateEquation amplitudes={amplitudes} n={n} />
       </div>
 
-      {/* Zone 2: Detail rows — exact amplitudes and probabilities */}
-      <div style={{
-        borderTop: '1px solid var(--border)',
-        background: 'var(--bg-raised)',
-        padding: '8px 12px 10px',
-      }}>
-        <BasisRows amplitudes={amplitudes} n={n} probs={probs} />
+      {/* Zone 2: Detail rows — collapsible */}
+      <div style={{ borderTop: '1px solid var(--border)', background: 'var(--bg-raised)' }}>
+        <AmplitudeToggle open={open} onToggle={() => setOpen((o: boolean) => !o)} />
+        {open && (
+          <div style={{ padding: '2px 12px 10px' }}>
+            <BasisRows amplitudes={amplitudes} n={n} probs={probs} />
+          </div>
+        )}
       </div>
     </>
   );
@@ -146,36 +147,41 @@ function MixedStateBody({ distribution, n }: { distribution: StateTracedState[];
   return (
     <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
       {distribution.map((branch, bi) => (
-        <div key={bi} style={{
-          border: '1px solid var(--border)',
-          borderLeft: '3px solid var(--amber, #f59e0b)',
-          borderRadius: 'var(--radius-sm)',
-          overflow: 'hidden',
-        }}>
-          <div style={{
-            padding: '4px 10px',
-            background: 'color-mix(in srgb, #f59e0b 6%, var(--bg-surface))',
-            fontFamily: 'var(--font-mono)', fontSize: 11,
-            color: 'var(--amber, #f59e0b)',
-          }}>
-            p = {(branch.probability * 100).toFixed(1)}%
-          </div>
-          <div style={{ padding: '10px 10px 8px' }}>
-            <StateEquation amplitudes={branch.amplitudes} n={n} />
-          </div>
-          <div style={{
-            borderTop: '1px solid var(--border)',
-            background: 'var(--bg-raised)',
-            padding: '6px 10px 8px',
-          }}>
-            <BasisRows
-              amplitudes={branch.amplitudes}
-              n={n}
-              probs={branch.amplitudes.map(([re, im]) => re * re + im * im)}
-            />
-          </div>
-        </div>
+        <BranchCard key={bi} branch={branch} n={n} />
       ))}
+    </div>
+  );
+}
+
+function BranchCard({ branch, n }: { branch: StateTracedState; n: number }) {
+  const [open, setOpen] = useState(true);
+  const probs = branch.amplitudes.map(([re, im]: [number, number]) => re * re + im * im);
+  return (
+    <div style={{
+      border: '1px solid var(--border)',
+      borderLeft: '3px solid var(--amber, #f59e0b)',
+      borderRadius: 'var(--radius-sm)',
+      overflow: 'hidden',
+    }}>
+      <div style={{
+        padding: '4px 10px',
+        background: 'color-mix(in srgb, #f59e0b 6%, var(--bg-surface))',
+        fontFamily: 'var(--font-mono)', fontSize: 11,
+        color: 'var(--amber, #f59e0b)',
+      }}>
+        p = {(branch.probability * 100).toFixed(1)}%
+      </div>
+      <div style={{ padding: '10px 10px 8px' }}>
+        <StateEquation amplitudes={branch.amplitudes} n={n} />
+      </div>
+      <div style={{ borderTop: '1px solid var(--border)', background: 'var(--bg-raised)' }}>
+        <AmplitudeToggle open={open} onToggle={() => setOpen((o: boolean) => !o)} />
+        {open && (
+          <div style={{ padding: '2px 10px 8px' }}>
+            <BasisRows amplitudes={branch.amplitudes} n={n} probs={probs} />
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -237,6 +243,29 @@ function StateEquation({ amplitudes, n }: { amplitudes: [number, number][]; n: n
   );
 }
 
+// ── Amplitude section toggle ──────────────────────────────────────────────
+
+function AmplitudeToggle({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+  return (
+    <button
+      onClick={onToggle}
+      style={{
+        width: '100%', display: 'flex', alignItems: 'center', gap: 5,
+        padding: '4px 12px', background: 'none', border: 'none',
+        cursor: 'pointer', color: 'var(--text-muted)',
+        fontFamily: 'var(--font-ui)', fontSize: 10,
+      }}
+    >
+      <span style={{
+        display: 'inline-block', fontSize: 8,
+        transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+        transition: 'transform 0.15s',
+      }}>▶</span>
+      amplitudes
+    </button>
+  );
+}
+
 // ── Detail rows ───────────────────────────────────────────────────────────
 
 function BasisRows({
@@ -244,7 +273,6 @@ function BasisRows({
 }: {
   amplitudes: [number, number][]; n: number; probs: number[];
 }) {
-  const maxProb = Math.max(...probs, 1e-12);
   const nonZeroCount = probs.filter(p => p > 1e-9).length;
   const showAll = (1 << n) <= 8;
 
@@ -259,7 +287,6 @@ function BasisRows({
           key={idx}
           basis={idx.toString(2).padStart(n, '0')}
           prob={prob}
-          maxProb={maxProb}
           re={re}
           im={im}
           dim={prob < 1e-9}
@@ -277,11 +304,11 @@ function BasisRows({
 // ── Single basis-state row ────────────────────────────────────────────────
 
 function BasisRow({
-  basis, prob, maxProb, re, im, dim,
+  basis, prob, re, im, dim,
 }: {
-  basis: string; prob: number; maxProb: number; re: number; im: number; dim: boolean;
+  basis: string; prob: number; re: number; im: number; dim: boolean;
 }) {
-  const pct = (prob / maxProb) * 100;
+  const pct = prob * 100;
   const label = formatAmplitude(re, im);
 
   return (

--- a/frontend/src/components/output/StateTab.tsx
+++ b/frontend/src/components/output/StateTab.tsx
@@ -1,0 +1,334 @@
+import React from 'react';
+import { usePlaygroundStore } from '../../lib/store';
+import type { StateSnapshot, StateTracedState } from '../../lib/types';
+
+export default function StateTab() {
+  const { runState } = usePlaygroundStore();
+
+  if (runState.status !== 'success') {
+    return <EmptyState kind="no-run" />;
+  }
+
+  const snapshots = runState.response.results?.state_snapshots?.[0];
+
+  if (!snapshots || snapshots.length === 0) {
+    return <EmptyState kind="no-snapshots" />;
+  }
+
+  return (
+    <div style={{
+      flex: 1, overflow: 'auto', padding: 16,
+      display: 'flex', flexDirection: 'column', gap: 12,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        marginBottom: 4,
+      }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
+          {snapshots.length} state snapshot{snapshots.length !== 1 ? 's' : ''} · shot 0
+        </span>
+      </div>
+      {snapshots.map((snap, i) => (
+        <SnapshotCard key={`${snap.tag}-${i}`} snapshot={snap} index={i} />
+      ))}
+    </div>
+  );
+}
+
+// ── Snapshot card ─────────────────────────────────────────────────────────
+
+function SnapshotCard({ snapshot, index }: { snapshot: StateSnapshot; index: number }) {
+  const { tag, specified_qubits, distribution } = snapshot;
+  const n = specified_qubits.length;
+  const isPure = distribution.length === 1 && Math.abs(distribution[0].probability - 1) < 1e-4;
+
+  return (
+    <div style={{
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius)',
+      overflow: 'hidden',
+    }}>
+      {/* Header */}
+      <div style={{
+        background: 'var(--bg-surface)',
+        borderBottom: '1px solid var(--border)',
+        padding: '7px 12px',
+        display: 'flex', alignItems: 'center', gap: 8,
+      }}>
+        <span style={{
+          fontFamily: 'var(--font-mono)', fontSize: 10,
+          color: 'var(--text-muted)',
+          background: 'var(--bg-raised)',
+          border: '1px solid var(--border)',
+          borderRadius: 3, padding: '1px 5px',
+          flexShrink: 0,
+        }}>
+          #{index + 1}
+        </span>
+        <code style={{
+          fontFamily: 'var(--font-mono)', fontSize: 12,
+          color: 'var(--teal)', flex: 1, minWidth: 0,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          state_result(<span style={{ color: 'var(--amber, #f59e0b)' }}>"{tag}"</span>, ···)
+        </code>
+        {!isPure && (
+          <span style={{
+            fontFamily: 'var(--font-ui)', fontSize: 10,
+            color: 'var(--amber, #f59e0b)',
+            background: 'color-mix(in srgb, #f59e0b 10%, transparent)',
+            border: '1px solid color-mix(in srgb, #f59e0b 30%, transparent)',
+            borderRadius: 3, padding: '1px 5px', flexShrink: 0,
+          }}>
+            mixed
+          </span>
+        )}
+        <span style={{
+          fontFamily: 'var(--font-ui)', fontSize: 11,
+          color: 'var(--text-muted)', flexShrink: 0,
+        }}>
+          {n} qubit{n !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Body */}
+      <div style={{ padding: 12 }}>
+        {isPure
+          ? <PureStateViz amplitudes={distribution[0].amplitudes} n={n} />
+          : <MixedStateViz distribution={distribution} n={n} />
+        }
+      </div>
+    </div>
+  );
+}
+
+// ── Pure state — single statevector ───────────────────────────────────────
+
+function PureStateViz({ amplitudes, n }: { amplitudes: [number, number][]; n: number }) {
+  const probs = amplitudes.map(([re, im]) => re * re + im * im);
+  const maxProb = Math.max(...probs, 1e-12);
+  const nonZero = probs.filter(p => p > 1e-9).length;
+  const showAll = 1 << n <= 8;  // always show all rows when ≤ 8 total basis states
+
+  const rows = amplitudes
+    .map(([re, im], idx) => ({ re, im, idx, prob: probs[idx] }))
+    .filter(r => showAll || r.prob > 1e-9);
+
+  if (rows.length === 0) {
+    return (
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
+        (all amplitudes zero)
+      </span>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+      {rows.map(({ re, im, idx, prob }) => (
+        <BasisRow
+          key={idx}
+          basis={idx.toString(2).padStart(n, '0')}
+          prob={prob}
+          maxProb={maxProb}
+          re={re}
+          im={im}
+          dim={prob < 1e-9}
+        />
+      ))}
+      {!showAll && nonZero < amplitudes.length && (
+        <span style={{
+          fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--text-muted)',
+          paddingTop: 2,
+        }}>
+          {amplitudes.length - nonZero} zero-amplitude basis state{amplitudes.length - nonZero !== 1 ? 's' : ''} hidden
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── Mixed state — distribution over pure states ───────────────────────────
+
+function MixedStateViz({ distribution, n }: { distribution: StateTracedState[]; n: number }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {distribution.map((branch, bi) => (
+        <div key={bi} style={{
+          border: '1px solid var(--border)',
+          borderLeft: `3px solid var(--amber, #f59e0b)`,
+          borderRadius: 'var(--radius-sm)',
+          overflow: 'hidden',
+        }}>
+          <div style={{
+            padding: '4px 10px',
+            background: 'color-mix(in srgb, #f59e0b 6%, var(--bg-surface))',
+            fontFamily: 'var(--font-mono)', fontSize: 11,
+            color: 'var(--amber, #f59e0b)',
+          }}>
+            p = {(branch.probability * 100).toFixed(1)}%
+          </div>
+          <div style={{ padding: '8px 10px' }}>
+            <PureStateViz amplitudes={branch.amplitudes} n={n} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Single basis-state row ─────────────────────────────────────────────────
+
+function BasisRow({
+  basis, prob, maxProb, re, im, dim,
+}: {
+  basis: string; prob: number; maxProb: number; re: number; im: number; dim: boolean;
+}) {
+  const pct = (prob / maxProb) * 100;
+  const label = formatAmplitude(re, im);
+
+  return (
+    <div style={{
+      display: 'grid',
+      gridTemplateColumns: 'auto 1fr auto auto',
+      alignItems: 'center',
+      gap: 8,
+      opacity: dim ? 0.25 : 1,
+    }}>
+      {/* Basis state label */}
+      <span style={{
+        fontFamily: 'var(--font-mono)', fontSize: 12,
+        color: 'var(--text-secondary)',
+        letterSpacing: '0.02em',
+        userSelect: 'none',
+      }}>
+        |{basis}⟩
+      </span>
+
+      {/* Probability bar */}
+      <div style={{
+        height: 14, background: 'var(--bg-raised)',
+        borderRadius: 2, overflow: 'hidden',
+        minWidth: 0,
+      }}>
+        <div style={{
+          width: `${pct}%`, height: '100%',
+          background: 'var(--teal)',
+          opacity: 0.75,
+          transition: 'width 0.2s ease',
+        }} />
+      </div>
+
+      {/* Percentage */}
+      <span style={{
+        fontFamily: 'var(--font-mono)', fontSize: 11,
+        color: prob > 1e-9 ? 'var(--text-secondary)' : 'var(--text-muted)',
+        minWidth: 38, textAlign: 'right',
+      }}>
+        {(prob * 100).toFixed(1)}%
+      </span>
+
+      {/* Amplitude */}
+      <span style={{
+        fontFamily: 'var(--font-mono)', fontSize: 11,
+        color: 'var(--text-muted)',
+        minWidth: 100, textAlign: 'right',
+        opacity: prob > 1e-9 ? 1 : 0.4,
+      }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function formatAmplitude(re: number, im: number): string {
+  const eps = 5e-4;
+  const reNear = Math.abs(re) < eps;
+  const imNear = Math.abs(im) < eps;
+  if (reNear && imNear) return '0';
+  if (reNear) return `${fmtN(im)}i`;
+  if (imNear) return fmtN(re);
+  const sign = im < 0 ? ' − ' : ' + ';
+  return `${fmtN(re)}${sign}${fmtN(Math.abs(im))}i`;
+}
+
+function fmtN(v: number): string {
+  // 3 significant decimal digits, strip trailing zeros
+  const s = v.toFixed(3);
+  return s.replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
+}
+
+// ── Empty states ──────────────────────────────────────────────────────────
+
+function EmptyState({ kind }: { kind: 'no-run' | 'no-snapshots' }) {
+  return (
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      padding: 32, gap: 16, textAlign: 'center',
+    }}>
+      <WaveIcon />
+      {kind === 'no-run' ? (
+        <>
+          <span style={{ fontFamily: 'var(--font-ui)', fontSize: 13, color: 'var(--text-secondary)', fontWeight: 500 }}>
+            Quantum state debugger
+          </span>
+          <span style={{ fontFamily: 'var(--font-ui)', fontSize: 12, color: 'var(--text-muted)', maxWidth: 320, lineHeight: 1.6 }}>
+            Run a program that calls <code style={{ fontFamily: 'var(--font-mono)', color: 'var(--teal)' }}>state_result()</code> to
+            snapshot intermediate quantum state at any point during execution.
+          </span>
+          <CodeHint />
+        </>
+      ) : (
+        <>
+          <span style={{ fontFamily: 'var(--font-ui)', fontSize: 13, color: 'var(--text-secondary)', fontWeight: 500 }}>
+            No state snapshots
+          </span>
+          <span style={{ fontFamily: 'var(--font-ui)', fontSize: 12, color: 'var(--text-muted)', maxWidth: 320, lineHeight: 1.6 }}>
+            Add <code style={{ fontFamily: 'var(--font-mono)', color: 'var(--teal)' }}>state_result("label", q)</code> calls
+            to your program to inspect the quantum state at any point.
+          </span>
+          <CodeHint />
+        </>
+      )}
+    </div>
+  );
+}
+
+function CodeHint() {
+  return (
+    <div style={{
+      background: 'var(--bg-surface)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius)',
+      padding: '10px 14px',
+      textAlign: 'left',
+      maxWidth: 340,
+    }}>
+      <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.7, color: 'var(--text-muted)' }}>
+        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}>from </span>
+        <span style={{ color: 'var(--text-secondary)' }}>guppylang.std.debug</span>
+        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}> import </span>
+        <span style={{ color: 'var(--teal)' }}>state_result</span>
+        <br />
+        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}>{'···'}</span>
+        <br />
+        <span style={{ color: 'var(--teal)' }}>state_result</span>
+        <span style={{ color: 'var(--text-secondary)' }}>(</span>
+        <span style={{ color: 'var(--amber, #f59e0b)' }}>"after_h"</span>
+        <span style={{ color: 'var(--text-secondary)' }}>, q)</span>
+        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}>  # snapshots |+⟩</span>
+      </div>
+    </div>
+  );
+}
+
+function WaveIcon() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 24 24" fill="none"
+      stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round">
+      <path d="M2 12 Q4 6 6 12 Q8 18 10 12 Q12 6 14 12 Q16 18 18 12 Q20 6 22 12" />
+    </svg>
+  );
+}

--- a/frontend/src/components/output/StateTab.tsx
+++ b/frontend/src/components/output/StateTab.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { usePlaygroundStore } from '../../lib/store';
 import type { StateSnapshot, StateTracedState } from '../../lib/types';
 
+const INV_SQRT2 = 1 / Math.sqrt(2);
+const EPS = 5e-4;
+const MAX_EQ_TERMS = 6;
+const SUBSCRIPTS = '₀₁₂₃₄₅₆₇₈₉';
+const toSub = (n: number) => String(n).split('').map(d => SUBSCRIPTS[+d]).join('');
+
 export default function StateTab() {
   const { runState } = usePlaygroundStore();
 
@@ -20,10 +26,7 @@ export default function StateTab() {
       flex: 1, overflow: 'auto', padding: 16,
       display: 'flex', flexDirection: 'column', gap: 12,
     }}>
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: 8,
-        marginBottom: 4,
-      }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
         <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
           {snapshots.length} state snapshot{snapshots.length !== 1 ? 's' : ''} · shot 0
         </span>
@@ -41,13 +44,10 @@ function SnapshotCard({ snapshot, index }: { snapshot: StateSnapshot; index: num
   const { tag, specified_qubits, distribution } = snapshot;
   const n = specified_qubits.length;
   const isPure = distribution.length === 1 && Math.abs(distribution[0].probability - 1) < 1e-4;
+  const basisLabel = `|${specified_qubits.map(q => `q${toSub(q)}`).join('')}⟩`;
 
   return (
-    <div style={{
-      border: '1px solid var(--border)',
-      borderRadius: 'var(--radius)',
-      overflow: 'hidden',
-    }}>
+    <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius)', overflow: 'hidden' }}>
       {/* Header */}
       <div style={{
         background: 'var(--bg-surface)',
@@ -60,8 +60,7 @@ function SnapshotCard({ snapshot, index }: { snapshot: StateSnapshot; index: num
           color: 'var(--text-muted)',
           background: 'var(--bg-raised)',
           border: '1px solid var(--border)',
-          borderRadius: 3, padding: '1px 5px',
-          flexShrink: 0,
+          borderRadius: 3, padding: '1px 5px', flexShrink: 0,
         }}>
           #{index + 1}
         </span>
@@ -84,6 +83,12 @@ function SnapshotCard({ snapshot, index }: { snapshot: StateSnapshot; index: num
           </span>
         )}
         <span style={{
+          fontFamily: 'var(--font-mono)', fontSize: 11,
+          color: 'var(--text-muted)', flexShrink: 0,
+        }}>
+          {basisLabel}
+        </span>
+        <span style={{
           fontFamily: 'var(--font-ui)', fontSize: 11,
           color: 'var(--text-muted)', flexShrink: 0,
         }}>
@@ -92,35 +97,160 @@ function SnapshotCard({ snapshot, index }: { snapshot: StateSnapshot; index: num
       </div>
 
       {/* Body */}
-      <div style={{ padding: 12 }}>
-        {isPure
-          ? <PureStateViz amplitudes={distribution[0].amplitudes} n={n} />
-          : <MixedStateViz distribution={distribution} n={n} />
-        }
-      </div>
+      {isPure
+        ? <PureStateBody amplitudes={distribution[0].amplitudes} n={n} />
+        : <MixedStateBody distribution={distribution} n={n} />
+      }
     </div>
   );
 }
 
-// ── Pure state — single statevector ───────────────────────────────────────
+// ── Pure state — equation hero + detail rows ──────────────────────────────
 
-function PureStateViz({ amplitudes, n }: { amplitudes: [number, number][]; n: number }) {
+function PureStateBody({ amplitudes, n }: { amplitudes: [number, number][]; n: number }) {
   const probs = amplitudes.map(([re, im]) => re * re + im * im);
+  const nonZeroCount = probs.filter(p => p > 1e-9).length;
+
+  if (nonZeroCount === 0) {
+    return (
+      <div style={{ padding: '12px 16px' }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13, color: 'var(--text-muted)' }}>
+          (all amplitudes zero)
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Zone 1: Dirac notation equation — the hero */}
+      <div style={{ padding: '14px 16px 12px' }}>
+        <StateEquation amplitudes={amplitudes} n={n} />
+      </div>
+
+      {/* Zone 2: Detail rows — exact amplitudes and probabilities */}
+      <div style={{
+        borderTop: '1px solid var(--border)',
+        background: 'var(--bg-raised)',
+        padding: '8px 12px 10px',
+      }}>
+        <BasisRows amplitudes={amplitudes} n={n} probs={probs} />
+      </div>
+    </>
+  );
+}
+
+// ── Mixed state — one branch sub-card per outcome ─────────────────────────
+
+function MixedStateBody({ distribution, n }: { distribution: StateTracedState[]; n: number }) {
+  return (
+    <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 10 }}>
+      {distribution.map((branch, bi) => (
+        <div key={bi} style={{
+          border: '1px solid var(--border)',
+          borderLeft: '3px solid var(--amber, #f59e0b)',
+          borderRadius: 'var(--radius-sm)',
+          overflow: 'hidden',
+        }}>
+          <div style={{
+            padding: '4px 10px',
+            background: 'color-mix(in srgb, #f59e0b 6%, var(--bg-surface))',
+            fontFamily: 'var(--font-mono)', fontSize: 11,
+            color: 'var(--amber, #f59e0b)',
+          }}>
+            p = {(branch.probability * 100).toFixed(1)}%
+          </div>
+          <div style={{ padding: '10px 10px 8px' }}>
+            <StateEquation amplitudes={branch.amplitudes} n={n} />
+          </div>
+          <div style={{
+            borderTop: '1px solid var(--border)',
+            background: 'var(--bg-raised)',
+            padding: '6px 10px 8px',
+          }}>
+            <BasisRows
+              amplitudes={branch.amplitudes}
+              n={n}
+              probs={branch.amplitudes.map(([re, im]) => re * re + im * im)}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Dirac notation equation ───────────────────────────────────────────────
+
+function StateEquation({ amplitudes, n }: { amplitudes: [number, number][]; n: number }) {
+  const terms = amplitudes
+    .map(([re, im], idx) => ({ re, im, idx, prob: re * re + im * im }))
+    .filter(t => t.prob > 1e-9);
+
+  if (terms.length === 0) {
+    return <span style={{ fontFamily: 'var(--font-mono)', fontSize: 15, color: 'var(--text-muted)' }}>0</span>;
+  }
+
+  const truncated = terms.length > MAX_EQ_TERMS;
+  const display = truncated ? terms.slice(0, MAX_EQ_TERMS) : terms;
+
+  return (
+    <div style={{
+      fontFamily: 'var(--font-mono)',
+      fontSize: 15,
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'baseline',
+      rowGap: 4,
+      userSelect: 'text',
+    }}>
+      {display.map((term, i) => {
+        const { sign, coeff } = termDisplay(term.re, term.im);
+        const ket = term.idx.toString(2).padStart(n, '0');
+        return (
+          <React.Fragment key={term.idx}>
+            {i === 0 && sign === '-' && (
+              <span style={{ color: 'var(--text-muted)', marginRight: 2 }}>−</span>
+            )}
+            {i > 0 && (
+              <span style={{ color: 'var(--text-muted)', margin: '0 5px' }}>
+                {sign === '-' ? '−' : '+'}
+              </span>
+            )}
+            {coeff && (
+              <span style={{ color: 'var(--text-secondary)', marginRight: 2 }}>{coeff}</span>
+            )}
+            <span>
+              <span style={{ color: 'var(--text-muted)' }}>|</span>
+              <span style={{ color: 'var(--teal)', letterSpacing: '0.04em' }}>{ket}</span>
+              <span style={{ color: 'var(--text-muted)' }}>⟩</span>
+            </span>
+          </React.Fragment>
+        );
+      })}
+      {truncated && (
+        <span style={{ color: 'var(--text-muted)', marginLeft: 6, fontSize: 13 }}>
+          + {terms.length - MAX_EQ_TERMS} more…
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── Detail rows ───────────────────────────────────────────────────────────
+
+function BasisRows({
+  amplitudes, n, probs,
+}: {
+  amplitudes: [number, number][]; n: number; probs: number[];
+}) {
   const maxProb = Math.max(...probs, 1e-12);
-  const nonZero = probs.filter(p => p > 1e-9).length;
-  const showAll = 1 << n <= 8;  // always show all rows when ≤ 8 total basis states
+  const nonZeroCount = probs.filter(p => p > 1e-9).length;
+  const showAll = (1 << n) <= 8;
 
   const rows = amplitudes
     .map(([re, im], idx) => ({ re, im, idx, prob: probs[idx] }))
     .filter(r => showAll || r.prob > 1e-9);
-
-  if (rows.length === 0) {
-    return (
-      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text-muted)' }}>
-        (all amplitudes zero)
-      </span>
-    );
-  }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
@@ -135,48 +265,16 @@ function PureStateViz({ amplitudes, n }: { amplitudes: [number, number][]; n: nu
           dim={prob < 1e-9}
         />
       ))}
-      {!showAll && nonZero < amplitudes.length && (
-        <span style={{
-          fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--text-muted)',
-          paddingTop: 2,
-        }}>
-          {amplitudes.length - nonZero} zero-amplitude basis state{amplitudes.length - nonZero !== 1 ? 's' : ''} hidden
+      {!showAll && nonZeroCount < amplitudes.length && (
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--text-muted)', paddingTop: 2 }}>
+          {amplitudes.length - nonZeroCount} zero-amplitude basis state{amplitudes.length - nonZeroCount !== 1 ? 's' : ''} hidden
         </span>
       )}
     </div>
   );
 }
 
-// ── Mixed state — distribution over pure states ───────────────────────────
-
-function MixedStateViz({ distribution, n }: { distribution: StateTracedState[]; n: number }) {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      {distribution.map((branch, bi) => (
-        <div key={bi} style={{
-          border: '1px solid var(--border)',
-          borderLeft: `3px solid var(--amber, #f59e0b)`,
-          borderRadius: 'var(--radius-sm)',
-          overflow: 'hidden',
-        }}>
-          <div style={{
-            padding: '4px 10px',
-            background: 'color-mix(in srgb, #f59e0b 6%, var(--bg-surface))',
-            fontFamily: 'var(--font-mono)', fontSize: 11,
-            color: 'var(--amber, #f59e0b)',
-          }}>
-            p = {(branch.probability * 100).toFixed(1)}%
-          </div>
-          <div style={{ padding: '8px 10px' }}>
-            <PureStateViz amplitudes={branch.amplitudes} n={n} />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ── Single basis-state row ─────────────────────────────────────────────────
+// ── Single basis-state row ────────────────────────────────────────────────
 
 function BasisRow({
   basis, prob, maxProb, re, im, dim,
@@ -194,7 +292,6 @@ function BasisRow({
       gap: 8,
       opacity: dim ? 0.25 : 1,
     }}>
-      {/* Basis state label */}
       <span style={{
         fontFamily: 'var(--font-mono)', fontSize: 12,
         color: 'var(--text-secondary)',
@@ -203,22 +300,13 @@ function BasisRow({
       }}>
         |{basis}⟩
       </span>
-
-      {/* Probability bar */}
-      <div style={{
-        height: 14, background: 'var(--bg-raised)',
-        borderRadius: 2, overflow: 'hidden',
-        minWidth: 0,
-      }}>
+      <div style={{ height: 14, background: 'var(--bg-base, var(--bg-raised))', borderRadius: 2, overflow: 'hidden', minWidth: 0 }}>
         <div style={{
           width: `${pct}%`, height: '100%',
-          background: 'var(--teal)',
-          opacity: 0.75,
+          background: 'var(--teal)', opacity: 0.75,
           transition: 'width 0.2s ease',
         }} />
       </div>
-
-      {/* Percentage */}
       <span style={{
         fontFamily: 'var(--font-mono)', fontSize: 11,
         color: prob > 1e-9 ? 'var(--text-secondary)' : 'var(--text-muted)',
@@ -226,8 +314,6 @@ function BasisRow({
       }}>
         {(prob * 100).toFixed(1)}%
       </span>
-
-      {/* Amplitude */}
       <span style={{
         fontFamily: 'var(--font-mono)', fontSize: 11,
         color: 'var(--text-muted)',
@@ -240,23 +326,54 @@ function BasisRow({
   );
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────
+// ── Term display helpers ──────────────────────────────────────────────────
+
+interface TermDisplay { sign: '+' | '-'; coeff: string }
+
+function termDisplay(re: number, im: number): TermDisplay {
+  const isReZero = Math.abs(re) < EPS;
+  const isImZero = Math.abs(im) < EPS;
+
+  if (!isReZero && isImZero) {
+    return { sign: re < 0 ? '-' : '+', coeff: realMagSymbol(Math.abs(re)) };
+  }
+  if (isReZero && !isImZero) {
+    const mag = realMagSymbol(Math.abs(im));
+    return { sign: im < 0 ? '-' : '+', coeff: mag ? `${mag}i` : 'i' };
+  }
+  // General complex: embed sign inside the parenthesised form
+  const imSign = im < 0 ? ' − ' : ' + ';
+  return { sign: '+', coeff: `(${fmtN(re)}${imSign}${fmtN(Math.abs(im))}i)` };
+}
+
+function realMagSymbol(abs: number): string {
+  if (Math.abs(abs - 1) < EPS)                      return '';       // omit — coefficient is 1
+  if (Math.abs(abs - INV_SQRT2) < EPS)              return '1/√2';
+  if (Math.abs(abs - 0.5) < EPS)                    return '1/2';
+  if (Math.abs(abs - Math.sqrt(3) / 2) < EPS)       return '√3/2';
+  if (Math.abs(abs - 1 / Math.sqrt(3)) < EPS)       return '1/√3';
+  return fmtN(abs);
+}
 
 function formatAmplitude(re: number, im: number): string {
-  const eps = 5e-4;
-  const reNear = Math.abs(re) < eps;
-  const imNear = Math.abs(im) < eps;
+  const reNear = Math.abs(re) < EPS;
+  const imNear = Math.abs(im) < EPS;
   if (reNear && imNear) return '0';
-  if (reNear) return `${fmtN(im)}i`;
-  if (imNear) return fmtN(re);
+  if (reNear) {
+    const mag = realMagSymbol(Math.abs(im)) || '1';
+    return im < 0 ? `−${mag}i` : `${mag}i`;
+  }
+  if (imNear) {
+    const mag = realMagSymbol(Math.abs(re)) || '1';
+    return re < 0 ? `−${mag}` : mag;
+  }
+  // General complex: fall back to decimal
   const sign = im < 0 ? ' − ' : ' + ';
   return `${fmtN(re)}${sign}${fmtN(Math.abs(im))}i`;
 }
 
 function fmtN(v: number): string {
-  // 3 significant decimal digits, strip trailing zeros
-  const s = v.toFixed(3);
-  return s.replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
+  return v.toFixed(3).replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
 }
 
 // ── Empty states ──────────────────────────────────────────────────────────
@@ -307,18 +424,18 @@ function CodeHint() {
       maxWidth: 340,
     }}>
       <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, lineHeight: 1.7, color: 'var(--text-muted)' }}>
-        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}>from </span>
+        <span style={{ opacity: 0.5 }}>from </span>
         <span style={{ color: 'var(--text-secondary)' }}>guppylang.std.debug</span>
-        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}> import </span>
+        <span style={{ opacity: 0.5 }}> import </span>
         <span style={{ color: 'var(--teal)' }}>state_result</span>
         <br />
-        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}>{'···'}</span>
+        <span style={{ opacity: 0.5 }}>{'···'}</span>
         <br />
         <span style={{ color: 'var(--teal)' }}>state_result</span>
         <span style={{ color: 'var(--text-secondary)' }}>(</span>
         <span style={{ color: 'var(--amber, #f59e0b)' }}>"after_h"</span>
         <span style={{ color: 'var(--text-secondary)' }}>, q)</span>
-        <span style={{ color: 'var(--text-muted)', opacity: 0.5 }}>  # snapshots |+⟩</span>
+        <span style={{ opacity: 0.5 }}>  # snapshots |+⟩</span>
       </div>
     </div>
   );

--- a/frontend/src/components/output/TerminalOutput.tsx
+++ b/frontend/src/components/output/TerminalOutput.tsx
@@ -3,7 +3,7 @@ import { usePlaygroundStore } from '../../lib/store';
 import type { RunState } from '../../lib/types';
 
 export default function TerminalOutput() {
-  const { runState } = usePlaygroundStore();
+  const { runState, simulator, source } = usePlaygroundStore();
   return (
     <div style={{
       flex: 1, padding: 16, fontFamily: 'var(--font-mono)',
@@ -15,12 +15,20 @@ export default function TerminalOutput() {
       '--text-muted':     '#6e7681',
       '--border':         '#30363d',
     } as React.CSSProperties}>
-      <TerminalContent state={runState} />
+      <TerminalContent state={runState} simulator={simulator} source={source} />
     </div>
   );
 }
 
-function TerminalContent({ state }: { state: RunState }) {
+function TerminalContent({ state, simulator, source }: { state: RunState; simulator: 'stabilizer' | 'statevector'; source: string }) {
+  // For a completed run, use the simulator that produced the results — not the currently-selected one.
+  const effectiveSim = state.status === 'success' ? state.simulator : simulator;
+  const simLabel = effectiveSim === 'statevector' ? 'Statevector' : 'Stabilizer';
+  // True when state_result() caused the simulator to be promoted to Statevector automatically
+  const autoStatevector = state.status === 'success'
+    && state.simulator === 'statevector'
+    && /\bstate_result\s*\(/.test(source);
+
   if (state.status === 'idle') {
     return <Line color="var(--text-muted)">Press ▶ Run or Ctrl+Enter to compile and simulate</Line>;
   }
@@ -30,7 +38,7 @@ function TerminalContent({ state }: { state: RunState }) {
       <>
         <Line color="var(--teal)">Compiling…</Line>
         <Blank />
-        <Line color="var(--text-muted)">  guppylang → HUGR IR → selene-sim</Line>
+        <Line color="var(--text-muted)">  guppylang → HUGR IR → selene-sim [{simLabel}]</Line>
         <Blank />
         <SpinnerLine label="Type checking" />
       </>
@@ -44,7 +52,7 @@ function TerminalContent({ state }: { state: RunState }) {
         <Line color="var(--green)">✓ Linearity check passed</Line>
         <Line color="var(--green)">✓ HUGR compiled</Line>
         <Blank />
-        <SpinnerLine label="Running Selene…" />
+        <SpinnerLine label={`Running Selene [${simLabel}]…`} />
       </>
     );
   }
@@ -52,9 +60,15 @@ function TerminalContent({ state }: { state: RunState }) {
   if (state.status === 'success') {
     const { response, elapsed_ms } = state;
     const compile = response.compile;
+    const shotCount = response.results
+      ? Object.values(response.results.counts).reduce((a, b) => a + b, 0).toLocaleString()
+      : '—';
     return (
       <>
-        <Line color="var(--text-muted)">  guppylang {compile ? `→ HUGR IR (${compile.node_count} nodes) → selene-sim` : '→ selene-sim'}</Line>
+        <Line color="var(--text-muted)">  guppylang {compile ? `→ HUGR IR (${compile.node_count} nodes) → selene-sim` : '→ selene-sim'} [{simLabel}]</Line>
+        {autoStatevector && (
+          <Line color="var(--teal)">  ℹ state_result() detected — Statevector enabled automatically</Line>
+        )}
         <Blank />
         {compile?.warnings.map((w, i) => (
           <Line key={i} color="var(--yellow)">⚠ line {w.line}: {w.message}</Line>
@@ -63,7 +77,7 @@ function TerminalContent({ state }: { state: RunState }) {
         <Line color="var(--green)">✓ Linearity check passed — no qubit leaks</Line>
         {compile && <Line color="var(--green)">✓ Compiled to HUGR ({compile.node_count} nodes)</Line>}
         <Blank />
-        <Line color="var(--teal)">Running {response.results ? Object.values(response.results.counts).reduce((a,b)=>a+b,0).toLocaleString() : '—'} shots…</Line>
+        <Line color="var(--teal)">Running {shotCount} shots · {simLabel}…</Line>
         <Blank />
         <Line color="var(--green)">✓ Simulation complete</Line>
         <Blank />

--- a/frontend/src/lib/examples.ts
+++ b/frontend/src/lib/examples.ts
@@ -185,4 +185,35 @@ def main() -> None:
 
 main.check()`,
   },
+  {
+    id: 'state-debug',
+    title: 'State Snapshots',
+    description: "Use state_result() to inspect the quantum state mid-circuit. Guppy's equivalent of print() debugging.",
+    tags: ['debugging', 'statevector'],
+    group: 'Debugging',
+    qubit_count: 2,
+    default_shots: 256,
+    source: `from guppylang import guppy
+from guppylang.std.quantum import qubit, h, cx, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result as guppy_result
+
+@guppy
+def main() -> None:
+    q0 = qubit()
+    q1 = qubit()
+
+    state_result("initial", q0, q1)   # |00⟩
+
+    h(q0)
+    state_result("after_h", q0, q1)   # |+0⟩ = (|00⟩ + |10⟩)/√2
+
+    cx(q0, q1)
+    state_result("bell", q0, q1)      # (|00⟩ + |11⟩)/√2
+
+    guppy_result("m0", measure(q0))
+    guppy_result("m1", measure(q1))
+
+main.check()`,
+  },
 ];

--- a/frontend/src/lib/examples.ts
+++ b/frontend/src/lib/examples.ts
@@ -187,7 +187,7 @@ main.check()`,
   },
   {
     id: 'state-debug',
-    title: 'State Snapshots',
+    title: 'Bell Pair Inspection',
     description: "Use state_result() to inspect the quantum state mid-circuit. Guppy's equivalent of print() debugging.",
     tags: ['debugging', 'statevector'],
     group: 'Debugging',
@@ -200,19 +200,234 @@ from guppylang.std.builtins import result as guppy_result
 
 @guppy
 def main() -> None:
+    """Bell pair preparation with state snapshots.
+
+    Walks through the two-gate sequence that creates a Bell state,
+    capturing the wavefunction after each step so you can see superposition
+    and entanglement appear one gate at a time.
+
+    Switch to Statevector simulator to see the State tab.
+    """
     q0 = qubit()
     q1 = qubit()
 
-    state_result("initial", q0, q1)   # |00⟩
+    state_result("1. initial", q0, q1)       # |00⟩ — both qubits in ground state
 
+    # H puts q0 into equal superposition
     h(q0)
-    state_result("after_h", q0, q1)   # |+0⟩ = (|00⟩ + |10⟩)/√2
+    state_result("2. after H", q0, q1)       # (|00⟩ + |10⟩)/√2 — q0 in |+⟩, q1 still |0⟩
 
+    # CNOT entangles q0 and q1 — creates the Bell state
     cx(q0, q1)
-    state_result("bell", q0, q1)      # (|00⟩ + |11⟩)/√2
+    state_result("3. Bell state", q0, q1)    # (|00⟩ + |11⟩)/√2 — maximally entangled
 
     guppy_result("m0", measure(q0))
     guppy_result("m1", measure(q1))
+
+main.check()`,
+  },
+  {
+    id: 'teleport-debug',
+    title: 'Quantum Teleportation Inspection',
+    description: 'Watch entanglement build and collapse during quantum teleportation using state_result() snapshots at each stage.',
+    tags: ['debugging', 'teleportation', 'statevector', 'intermediate'],
+    group: 'Debugging',
+    qubit_count: 3,
+    default_shots: 256,
+    source: `from guppylang import guppy
+from guppylang.std.builtins import owned, result
+from guppylang.std.quantum import cx, h, measure, qubit, x, z
+from guppylang.std.debug import state_result
+
+@guppy
+def main() -> None:
+    """Quantum teleportation with state inspection.
+
+    Teleports src (prepared in |+>) to tgt using an entangled ancilla tmp.
+    state_result() snapshots the full 3-qubit wavefunction at each stage,
+    letting you watch entanglement build and collapse through the protocol.
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    src = qubit()   # qubit to teleport — prepared in |+>
+    tmp = qubit()   # ancilla — entangled with tgt to form the Bell channel
+    tgt = qubit()   # destination qubit
+
+    # Prepare src in |+> = (|0> + |1>)/sqrt(2)
+    h(src)
+    state_result("1. src in |+>", src, tmp, tgt)
+
+    # Entangle tmp and tgt — creates the Bell channel
+    h(tmp)
+    cx(tmp, tgt)
+    state_result("2. Bell channel ready", src, tmp, tgt)
+
+    # Joint Bell measurement on src and tmp
+    cx(src, tmp)
+    h(src)
+    state_result("3. Before measurement", src, tmp, tgt)
+
+    # Mid-circuit measurement — wavefunction collapses here
+    m_src = measure(src)
+    m_tmp = measure(tmp)
+
+    # Classical feedforward corrections on tgt
+    if m_tmp:
+        x(tgt)
+    if m_src:
+        z(tgt)
+
+    # tgt now holds the teleported |+> state
+    state_result("4. After correction (tgt only)", tgt)
+    result("tgt", measure(tgt))
+
+main.check()`,
+  },
+  {
+    id: 'ghz-debug',
+    title: 'GHZ State Inspection',
+    description: 'Watch 3-qubit GHZ entanglement spread step by step using state_result() as each CNOT is applied.',
+    tags: ['debugging', 'entanglement', 'statevector', 'intermediate'],
+    group: 'Debugging',
+    qubit_count: 3,
+    default_shots: 256,
+    source: `from guppylang import guppy
+from guppylang.std.quantum import qubit, h, cx, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result
+
+@guppy
+def main() -> None:
+    """GHZ state preparation with state snapshots.
+
+    Watch entanglement spread qubit by qubit as each CNOT is applied,
+    building the 3-qubit GHZ state (|000> + |111>)/sqrt(2).
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    q0 = qubit()
+    q1 = qubit()
+    q2 = qubit()
+
+    state_result("1. initial", q0, q1, q2)            # |000>
+
+    h(q0)
+    state_result("2. after H on q0", q0, q1, q2)      # (|000> + |100>)/sqrt(2)
+
+    cx(q0, q1)
+    state_result("3. after cx(q0,q1)", q0, q1, q2)    # (|000> + |110>)/sqrt(2)
+
+    cx(q1, q2)
+    state_result("4. GHZ ready", q0, q1, q2)          # (|000> + |111>)/sqrt(2)
+
+    result("q0", measure(q0))
+    result("q1", measure(q1))
+    result("q2", measure(q2))
+
+main.check()`,
+  },
+  {
+    id: 'deutsch-debug',
+    title: 'Deutsch Algorithm Inspection',
+    description: 'See phase kickback in action — watch how the oracle encodes f(x) as a global phase and the final H converts it to a measurable bit.',
+    tags: ['debugging', 'algorithm', 'statevector', 'intermediate'],
+    group: 'Debugging',
+    qubit_count: 2,
+    default_shots: 256,
+    source: `from guppylang import guppy
+from guppylang.std.quantum import qubit, h, cx, x, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result
+
+@guppy
+def main() -> None:
+    """Deutsch algorithm with state snapshots.
+
+    Watch how the balanced oracle encodes f(x) as a global phase via
+    kickback, and how the final Hadamard converts that into a measurable bit.
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    q   = qubit()
+    anc = qubit()
+
+    state_result("1. initial", q, anc)           # |00>
+
+    h(q)
+    x(anc)
+    h(anc)
+    state_result("2. |+-> prepared", q, anc)     # query register in |+->
+
+    # Balanced oracle: f(x) = x
+    cx(q, anc)
+    state_result("3. after oracle", q, anc)      # phase kickback applied
+
+    h(q)
+    state_result("4. after final H", q, anc)     # q collapses to |1> — balanced
+
+    result("result", measure(q))
+    result("anc", measure(anc))
+
+main.check()`,
+  },
+  {
+    id: 'qec-debug',
+    title: 'Bit Flip Code Inspection',
+    description: 'Watch the QEC cycle: encode a logical qubit, inject an error, measure syndromes, and verify the corrected state with state_result().',
+    tags: ['debugging', 'error-correction', 'statevector', 'advanced'],
+    group: 'Debugging',
+    qubit_count: 5,
+    default_shots: 256,
+    source: `from guppylang import guppy
+from guppylang.std.quantum import qubit, cx, x, measure
+from guppylang.std.debug import state_result
+from guppylang.std.builtins import result
+
+@guppy
+def main() -> None:
+    """3-qubit bit-flip code with state snapshots.
+
+    Watch the logical |0> get encoded across three physical qubits,
+    a bit-flip error get injected, syndromes measured, and the state restored.
+
+    Switch to Statevector simulator to see the State tab.
+    """
+    q0 = qubit()
+    q1 = qubit()
+    q2 = qubit()
+
+    state_result("1. initial |000>", q0, q1, q2)
+
+    # Encode logical |0> -> |000>
+    cx(q0, q1)
+    cx(q0, q2)
+    state_result("2. encoded |000>", q0, q1, q2)
+
+    # Inject a bit-flip error on q1
+    x(q1)
+    state_result("3. after error on q1", q0, q1, q2)
+
+    # Syndrome measurement via ancilla qubits
+    anc0 = qubit()
+    anc1 = qubit()
+    cx(q0, anc0); cx(q1, anc0)
+    cx(q1, anc1); cx(q2, anc1)
+    s0 = measure(anc0)
+    s1 = measure(anc1)
+
+    # Correction
+    if s0 and not s1:
+        x(q0)
+    if s0 and s1:
+        x(q1)
+    if not s0 and s1:
+        x(q2)
+
+    state_result("4. after correction", q0, q1, q2)
+
+    result("q0", measure(q0))
+    result("q1", measure(q1))
+    result("q2", measure(q2))
 
 main.check()`,
   },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -47,6 +47,18 @@ export interface CompileError {
   kind: ErrorKind;
 }
 
+export interface StateTracedState {
+  probability: number;
+  amplitudes: [number, number][];   // [re, im] per basis state
+}
+
+export interface StateSnapshot {
+  tag: string;
+  num_qubits: number;               // total qubits in full system
+  specified_qubits: number[];       // which qubits this call captured
+  distribution: StateTracedState[]; // usually 1 entry for pure states
+}
+
 export interface SimulationResults {
   counts: Record<string, number>;
   noisy_counts?: Record<string, number>;
@@ -54,6 +66,7 @@ export interface SimulationResults {
   expectation_values?: Record<string, number>;
   statevector?: Array<{ amplitude: [number, number]; basis: string }>;
   simulate_time_ms: number;
+  state_snapshots?: StateSnapshot[][];  // [shot][call-order]
 }
 
 export type RunStatus = 'ok' | 'compile_error' | 'timeout' | 'rate_limited' | 'internal_error';
@@ -101,4 +114,4 @@ export type RunState =
   | { status: 'rate_limited'; retry_after_ms: number }
   | { status: 'internal_error'; message: string };
 
-export type OutputTab = 'output' | 'results' | 'hugr';
+export type OutputTab = 'output' | 'results' | 'state' | 'hugr';

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -108,7 +108,7 @@ export type RunState =
   | { status: 'preparing' }
   | { status: 'compiling' }
   | { status: 'simulating' }
-  | { status: 'success'; response: RunResponse; elapsed_ms: number }
+  | { status: 'success'; response: RunResponse; elapsed_ms: number; simulator: SimulatorBackend }
   | { status: 'compile_error'; errors: CompileError[] }
   | { status: 'timeout' }
   | { status: 'rate_limited'; retry_after_ms: number }


### PR DESCRIPTION
## State Debugger — `state_result()` tab

Adds a dedicated **State** tab to the output panel that displays quantum state snapshots captured mid-circuit via `state_result()`. This gives users a `print()`-style debugging workflow for quantum programs: call `state_result("label", q0, q1, ...)` at any point and inspect the full wavefunction at that moment.

## What's included

### Backend
- New `StateSnapshot` / `StateTracedState` models carrying per-shot amplitude data
- `_extract_state_snapshots()` in the compile worker serialises `partial_states()` from the emulator result into JSON-safe amplitude dicts (up to 8 qubits / 256 amplitudes per snapshot, up to 5 shots)
- When the stabilizer simulator is used, a secondary statevector pass is run automatically to extract state data — users don't need to switch simulators manually just to get snapshots
- Fixes to `_flatten_counts` and `_extract_register_names` to skip artifact paths written by `state_result()` into the register file
- Removes the multi-version guppylang switching infrastructure (version parameter, `uv`-based worker dispatch, `/versions` route)

### Frontend
- New `StateTab` component with:
  - Dirac notation equation hero (e.g. `1/√2 |00⟩ + 1/√2 |11⟩`) for pure states
  - Per-basis-state rows with probability bar chart, percentage, and exact amplitude
  - Mixed state display with per-branch probability headers
  - Collapsible amplitude rows section per card
  - Shot picker (`‹ 0 › / 4`) when multiple shots of state data are available
  - Scrollable card list that doesn't compress cards on overflow
  - Bar chart widths reflect absolute probability (50% = half bar, 100% = full bar)
- Auto-switches to State tab after a run if `state_result()` is detected in source
- Auto-detects statevector simulator from the run result and pre-selects it in the toolbar

### Examples
New **Debugging** group with 5 annotated examples:
- Bell Pair Inspection
- Quantum Teleportation Inspection
- GHZ State Inspection
- Deutsch Algorithm Inspection
- Bit Flip Code Inspection

## Test plan
- [ ] Run Bell Pair Inspection with Statevector — State tab shows 3 snapshots with correct amplitudes at each step
- [ ] Run Teleportation Inspection — mixed state cards appear after mid-circuit measurement
- [ ] Run any example with Stabilizer simulator — State tab still populates via secondary statevector pass
- [ ] Collapse/expand amplitude rows per card
- [ ] Shot picker appears and navigates correctly when running with multiple shots
- [ ] Results tab and terminal output unaffected by programs that use `state_result()`
